### PR TITLE
Fix encodeComponent export by avoiding destructuring with rename

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -10,7 +10,7 @@ import {
 import { isObject } from './objects.js'
 import { isNonEmptyString } from './strings.js'
 
-const { encodeURIComponent: encodeComponent } = globalThis
+const encodeComponent = globalThis.encodeURIComponent
 
 function encodeName(name: unknown): string {
   return isNonEmptyString(name)


### PR DESCRIPTION
> _Howdy @jdalton 👋 been a few years. Hope that you've been doing well 🙏_ 

## What is the issue? 

The simplest possible repro via `node -pe`:

```bash
pnpm install @socketregistry/packageurl-js@1.1.2

node -pe "(new (require('@socketregistry/packageurl-js').PackageURL)('npm', '@babel', 'runtime', '7.18.6', null, 'helpers/typeof.js').toString())"
```

yields

```bash
./node_modules/.pnpm/@socketregistry+packageurl-js@1.1.2/node_modules/@socketregistry/packageurl-js/dist/purl-type.js:316
            if ((0, encode_js_1.encodeComponent)(name) !== name) {
                                                ^

TypeError: (0 , encode_js_1.encodeComponent) is not a function
    at Object.npm [as validate] (./node_modules/.pnpm/@socketregistry+packageurl-js@1.1.2/node_modules/@socketregistry/packageurl-js/dist/purl-type.js:316:49)
    at new PackageURL (./node_modules/.pnpm/@socketregistry+packageurl-js@1.1.2/node_modules/@socketregistry/packageurl-js/dist/package-url.js:103:40)
    at [eval]:1:2
    at runScriptInThisContext (node:internal/vm:209:10)
    at node:internal/process/execution:449:12
    at [eval]-wrapper:6:24
    at runScriptInContext (node:internal/process/execution:447:60)
    at evalFunction (node:internal/process/execution:87:30)
    at evalScript (node:internal/process/execution:99:3)
    at node:internal/main/eval_string:74:3
```

The 1-liner above is just the `node -pe` equivalent to the example from `README.md`:

```js
import { PackageURL } from '@socketregistry/packageurl-js';

const subpathPurl = new PackageURL('npm', '@babel', 'runtime', '7.18.6', null, 'helpers/typeof.js')

console.log(subpathPurl.toString());
```

## Why does this fix the issue? 

There appears to be a subtle bug in `tsgo` that is causing the destructured version of this assignment to transpile to:

``` js
exports.encodeComponent = void 0;
``` 

I'm far from an expert in that domain, but this does resolve the issue:

```bash
# Checkout the branch

# Blow away any existing `tsconfig.tsbuildinfo`
rm -f tsconfig.tsbuildinfo

# Rebuild via tsgo
pnpm build

# Get the result expected
node -pe "(new (require('./dist/index.js').PackageURL)('npm', '@babel', 'runtime', '7.18.6', null, 'helpers/typeof.js').toString())"
```

which yields

```bash
pkg:npm/%40babel/runtime@7.18.6#helpers/typeof.js
```