### PR TITLE
fix(deps): always update Socket packages in update script

### DIFF
--- a/scripts/update.mjs
+++ b/scripts/update.mjs
@@ -49,40 +49,38 @@ async function main() {
       process.stdout.write('\r\x1b[K')
     }
 
-    // Always update Socket packages when applying (bypass taze maturity period).
-    if (apply) {
+    // Always update Socket packages (bypass taze maturity period).
+    if (!quiet) {
+      logger.progress('Updating Socket packages...')
+    }
+
+    const socketResult = await spawn(
+      'pnpm',
+      [
+        'update',
+        '@socketsecurity/*',
+        '@socketregistry/*',
+        '@socketbin/*',
+        '--latest',
+        '-r',
+      ],
+      {
+        shell: WIN32,
+        stdio: quiet ? 'pipe' : 'inherit',
+      },
+    )
+
+    // Clear progress line.
+    if (!quiet) {
+      process.stdout.write('\r\x1b[K')
+    }
+
+    if (socketResult.code !== 0) {
       if (!quiet) {
-        logger.progress('Updating Socket packages...')
+        logger.fail('Failed to update Socket packages')
       }
-
-      const socketResult = await spawn(
-        'pnpm',
-        [
-          'update',
-          '@socketsecurity/*',
-          '@socketregistry/*',
-          '@socketbin/*',
-          '--latest',
-          '-r',
-        ],
-        {
-          shell: WIN32,
-          stdio: quiet ? 'pipe' : 'inherit',
-        },
-      )
-
-      // Clear progress line.
-      if (!quiet) {
-        process.stdout.write('\r\x1b[K')
-      }
-
-      if (socketResult.code !== 0) {
-        if (!quiet) {
-          logger.fail('Failed to update Socket packages')
-        }
-        process.exitCode = 1
-        return
-      }
+      process.exitCode = 1
+      return
     }
 
     if (result.code !== 0) {


### PR DESCRIPTION
## Summary

The update script was only updating `@socketsecurity/*`, `@socketregistry/*`, and `@socketbin/*` packages when the `--apply` flag was passed. This meant newly released Socket packages within taze's 7-day maturity period were being skipped during regular `pnpm run update` runs.

## Changes

- Removed the `if (apply)` condition around Socket package updates
- Socket packages are now always updated to bypass taze's maturity period
- Ensures teams get the latest Socket packages immediately on every update run

## Test plan

- [x] Run `pnpm run update` without `--apply`
- [x] Verify Socket packages are updated to latest versions
- [x] All tests pass