### PR TITLE
fix: properly disable dependabot and fix lint for non-lintable files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,10 @@
 # Dependabot disabled - we manage dependencies manually
+# Using open-pull-requests-limit: 0 to disable version updates
+# See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
-updates: []
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: yearly
+    open-pull-requests-limit: 0

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -63,6 +63,7 @@ function shouldRunAllLinters(changedFiles) {
  * Filter files to only those that should be linted.
  */
 function filterLintableFiles(files) {
+  // Only include extensions actually supported by oxfmt/oxlint
   const lintableExtensions = new Set([
     '.js',
     '.mjs',
@@ -70,11 +71,6 @@ function filterLintableFiles(files) {
     '.ts',
     '.cts',
     '.mts',
-    '.json',
-    '.jsonc',
-    '.md',
-    '.yml',
-    '.yaml',
   ])
 
   return files.filter(file => {


### PR DESCRIPTION
## Summary
- Properly disable Dependabot using `open-pull-requests-limit: 0` instead of empty `updates: []`
- Fix lint script to only include extensions actually supported by oxfmt/oxlint

## Details
The previous `updates: []` approach caused GitHub to fail validation. Using `open-pull-requests-limit: 0` with `interval: yearly` effectively disables Dependabot while satisfying the schema.