### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     schedule:
       interval: yearly
     open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add `cooldown: default-days: 7` to Dependabot npm updater to mitigate risk of pulling compromised dependencies immediately after release (dependabot-cooldown finding)

## Remaining findings
- 3 suppressed (below medium severity) -- no action needed