### PR TITLE
chore: bump @socketsecurity/lib to 5.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/parser": "7.29.0",
     "@dotenvx/dotenvx": "1.52.0",
     "@oxlint/migrate": "1.51.0",
-    "@socketsecurity/lib": "5.11.2",
+    "@socketsecurity/lib": "5.11.3",
     "@socketsecurity/registry": "2.0.2",
     "@types/node": "24.9.2",
     "@types/picomatch": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
       '@socketsecurity/lib':
-        specifier: 5.11.2
-        version: 5.11.2(typescript@5.9.2)
+        specifier: 5.11.3
+        version: 5.11.3(typescript@5.9.2)
       '@socketsecurity/registry':
         specifier: 2.0.2
         version: 2.0.2(typescript@5.9.2)
@@ -963,8 +963,8 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/lib@5.11.2':
-    resolution: {integrity: sha512-TS6oTeakMCbOrz73mSin/0lOhAyAr6+tlvzAvaASnMhjhrcQ9tPP816be1ZgtDRYolvQHMT+WPSmajlTHTQHjw==}
+  '@socketsecurity/lib@5.11.3':
+    resolution: {integrity: sha512-Jp6TSn8ATHrTtw/kTFXmVr+cZwZVuX9wqym/FQ3n8GSAgByUPJJdzWMLzHVFK1HaQRK4kVdB5Db3IKXdFkpQ2Q==}
     engines: {node: '>=22', pnpm: '>=10.25.0'}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -2831,7 +2831,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@socketsecurity/lib@5.11.2(typescript@5.9.2)':
+  '@socketsecurity/lib@5.11.3(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 


### PR DESCRIPTION
## Summary
- Bump `@socketsecurity/lib` from 5.11.2 to 5.11.3