### PR TITLE
fix(test): increase timeout for network-dependent purlExists tests

### DIFF
--- a/test/purl-edge-cases.test.mts
+++ b/test/purl-edge-cases.test.mts
@@ -2221,13 +2221,13 @@ describe('Edge cases and additional coverage', () => {
       const result = await purlExists(purl)
       // Network call may succeed or fail, but it should not return "Unsupported type"
       expect(result.error).not.toBe('Unsupported type: conda')
-    }, 30_000)
+    }, 15_000)
 
     it('should dispatch docker type', async () => {
       const purl = PackageURL.fromString('pkg:docker/nginx@latest')
       const result = await purlExists(purl)
       expect(result.error).not.toBe('Unsupported type: docker')
-    }, 30_000)
+    }, 15_000)
   })
 
   describe('UrlConverter edge cases', () => {

--- a/test/purl-edge-cases.test.mts
+++ b/test/purl-edge-cases.test.mts
@@ -2221,13 +2221,13 @@ describe('Edge cases and additional coverage', () => {
       const result = await purlExists(purl)
       // Network call may succeed or fail, but it should not return "Unsupported type"
       expect(result.error).not.toBe('Unsupported type: conda')
-    })
+    }, 30_000)
 
     it('should dispatch docker type', async () => {
       const purl = PackageURL.fromString('pkg:docker/nginx@latest')
       const result = await purlExists(purl)
       expect(result.error).not.toBe('Unsupported type: docker')
-    })
+    }, 30_000)
   })
 
   describe('UrlConverter edge cases', () => {


### PR DESCRIPTION
## Summary
- The `should dispatch conda type` test makes a real HTTP request to anaconda.org which timed out on CI at the default 10s vitest limit, failing the v1.4.0 publish workflow
- Increase timeout to 30s for both conda and docker `purlExists` network tests

## Test plan
- [x] `pnpm test` passes locally
- [x] CI should pass with the increased timeout