### PR TITLE
chore(ci): update socket-registry workflow refs to latest main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@dd7ea0c4fe523792f75c4002b20e2e5c2e14c066 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@b809e72d069356dfaf490134e9a20226dd9376c1 # main
     with:
       fail-fast: false
       lint-script: 'pnpm run lint --all'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@dd7ea0c4fe523792f75c4002b20e2e5c2e14c066 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@b809e72d069356dfaf490134e9a20226dd9376c1 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}


### PR DESCRIPTION
## Summary
- Update `SocketDev/socket-registry` reusable workflow SHA refs to latest main (`b809e72d`) which adds Node.js 24 support and drops Node.js 20 (EOL) from the default test matrix

## Test plan
- [x] CI should pass without Node.js deprecation warnings