### PR TITLE
chore: add minimum release age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,5 +6,10 @@ link-workspace-packages=false
 loglevel=error
 prefer-workspace-packages=false
 
+# Minimum release age - wait 7 days before installing newly published packages
+# pnpm uses minimum-release-age (minutes), npm v11+ uses min-release-age (days)
+minimum-release-age=10080
+min-release-age=7
+
 # Trust policy - prevent downgrade attacks
 trust-policy=no-downgrade


### PR DESCRIPTION
## Summary
- Add `minimum-release-age=10080` (pnpm, minutes) and `min-release-age=7` (npm v11+, days) to `.npmrc`
- Enforces a 7-day waiting period before installing newly published packages, reducing supply chain attack risk
- pnpm reads `minimum-release-age` from `.npmrc`; npm v11+ reads `min-release-age`; each ignores the other's key

## Test plan
- [ ] CI passes