### PR TITLE
chore(ci): add GPG commit signing to weekly-update workflow

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -57,11 +57,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH_NAME="weekly-update-$(date +%Y%m%d)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+        with:
+          gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
       - name: Run updating skill with Claude Code
         id: claude
@@ -152,6 +154,9 @@ jobs:
           name: claude-output-${{ github.run_id }}
           path: claude-output.log
           retention-days: 7
+
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+        if: always()
 
   notify:
     name: Notify results

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -81,7 +81,28 @@ jobs:
           set +e
           pnpm exec claude --print --dangerously-skip-permissions \
             --model sonnet \
-            "/updating - Run the updating skill to update all dependencies. Create atomic commits for each update. You are running in CI mode - skip builds and tests. Do not push or create a PR." \
+            "$(cat <<'PROMPT'
+          /updating
+
+          <context>
+          You are an automated CI agent in a weekly dependency update workflow.
+          Git is configured with GPG signing. A branch has been created for you.
+          </context>
+
+          <instructions>
+          Update all dependencies to their latest versions.
+          Create one atomic commit per dependency update with a conventional commit message.
+          Leave all changes local — the workflow handles pushing and PR creation.
+          Skip running builds, tests, and type checks — CI runs those separately.
+          </instructions>
+
+          <success_criteria>
+          Each updated dependency has its own commit.
+          The lockfile is consistent with package.json changes.
+          No uncommitted changes remain in the working tree.
+          </success_criteria>
+          PROMPT
+          )" \
             2>&1 | tee claude-output.log
           CLAUDE_EXIT=${PIPESTATUS[0]}
           set -e


### PR DESCRIPTION
Add setup-git-signing/cleanup-git-signing actions and structured /updating prompt.