### PR TITLE
fix: move minimum-release-age to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,9 +6,8 @@ link-workspace-packages=false
 loglevel=error
 prefer-workspace-packages=false
 
-# Minimum release age - wait 7 days before installing newly published packages
-# pnpm uses minimum-release-age (minutes), npm v11+ uses min-release-age (days)
-minimum-release-age=10080
+# Minimum release age for npm v11+ (days).
+# pnpm equivalent is in pnpm-workspace.yaml (minimumReleaseAge).
 min-release-age=7
 
 # Trust policy - prevent downgrade attacks

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+settings:
+  # Wait 7 days (10080 minutes) before installing newly published packages.
+  minimumReleaseAge: 10080


### PR DESCRIPTION
Move pnpm's minimum-release-age from .npmrc to pnpm-workspace.yaml to avoid npm v11+ unknown config warning.