### PR TITLE
fix: zizmor template-injection + standardize format scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
     with:
       fail-fast: false
       lint-script: 'pnpm run lint --all'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -214,16 +214,16 @@ jobs:
       - name: Set final status
         id: final
         if: always()
+        env:
+          UPDATE_SUCCESS: ${{ steps.update.outputs.success }}
+          TESTS_SUCCESS: ${{ steps.tests.outputs.success }}
+          FIX_SUCCESS: ${{ steps.claude.outputs.success }}
         run: |
-          UPDATE="${{ steps.update.outputs.success }}"
-          TESTS="${{ steps.tests.outputs.success }}"
-          FIX="${{ steps.claude.outputs.success }}"
-
-          if [ "$UPDATE" != "true" ]; then
+          if [ "$UPDATE_SUCCESS" != "true" ]; then
             echo "success=false" >> $GITHUB_OUTPUT
-          elif [ "$TESTS" = "true" ]; then
+          elif [ "$TESTS_SUCCESS" = "true" ]; then
             echo "success=true" >> $GITHUB_OUTPUT
-          elif [ "$FIX" = "true" ]; then
+          elif [ "$FIX_SUCCESS" = "true" ]; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
 
       - name: Create update branch
         id: branch
@@ -61,7 +61,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -312,7 +312,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
         if: always()
 
   notify:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "clean": "node scripts/clean.mjs",
     "cover": "node scripts/cover.mjs",
     "fix": "node scripts/fix.mjs",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
     "lint": "node scripts/lint.mjs",
     "precommit": "pnpm run check --lint --staged",
     "prepare": "husky",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
-settings:
-  # Wait 7 days (10080 minutes) before installing newly published packages.
-  minimumReleaseAge: 10080
+# Wait 7 days (10080 minutes) before installing newly published packages.
+minimumReleaseAge: 10080


### PR DESCRIPTION
- Use env vars instead of template expressions in run blocks (zizmor audit)
- Add format/format:check scripts (oxfmt --write/--check)