### PR TITLE
chore(ci): bump socket-registry action refs to latest main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
     with:
       fail-fast: false
       lint-script: 'pnpm run lint --all'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
 
       - name: Create update branch
         id: branch
@@ -61,7 +61,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -312,7 +312,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@eb7b4d0f83520afab82cfffd8f5462241e6526b7 # main
         if: always()
 
   notify:


### PR DESCRIPTION
Updates all SocketDev/socket-registry action/workflow refs to eb7b4d0f (includes npm self-upgrade fix for Node 22).