### PR TITLE
chore(deps): bump @socketsecurity/lib to 5.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/parser": "7.29.0",
     "@dotenvx/dotenvx": "1.52.0",
     "@oxlint/migrate": "1.51.0",
-    "@socketsecurity/lib": "5.11.4",
+    "@socketsecurity/lib": "5.12.0",
     "@socketsecurity/registry": "2.0.2",
     "@types/node": "24.9.2",
     "@types/picomatch": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
       '@socketsecurity/lib':
-        specifier: 5.11.4
-        version: 5.11.4(typescript@5.9.2)
+        specifier: 5.12.0
+        version: 5.12.0(typescript@5.9.2)
       '@socketsecurity/registry':
         specifier: 2.0.2
         version: 2.0.2(typescript@5.9.2)
@@ -1070,8 +1070,8 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/lib@5.11.4':
-    resolution: {integrity: sha512-3/stIFexg45DNhGvpw/U49UFuHYe0ZLS45scuYw83HfWrHmL7h9Mi4m27C3/ihAF6O9uOJSKBsWBIHlTM8Wikg==}
+  '@socketsecurity/lib@5.12.0':
+    resolution: {integrity: sha512-OLTHvVBRpfwpVHzlDFPl5kxJ6xifOVqbPLc8AqFh+tujzeiIG87yvTijxRnA5G4dqaffujkK7jkxM71UQkyK0w==}
     engines: {node: '>=22', pnpm: '>=10.25.0'}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -3012,7 +3012,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@socketsecurity/lib@5.11.4(typescript@5.9.2)':
+  '@socketsecurity/lib@5.12.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 # Wait 7 days (10080 minutes) before installing newly published packages.
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@socketaddon/*'
+  - '@socketbin/*'
+  - '@socketregistry/*'
+  - '@socketsecurity/*'


### PR DESCRIPTION
## Summary
- Bump `@socketsecurity/lib` from 5.11.4 to 5.12.0 in package.json devDependencies