### PR TITLE
chore(deps): bump @anthropic-ai/claude-code to 2.1.92 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "update:data:npm": "node scripts/update-data-npm.mjs"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "2.1.89",
+    "@anthropic-ai/claude-code": "2.1.92",
     "@babel/parser": "7.29.0",
     "@dotenvx/dotenvx": "1.52.0",
     "@oxlint/migrate": "1.51.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 4.0.3
     devDependencies:
       '@anthropic-ai/claude-code':
-        specifier: 2.1.89
-        version: 2.1.89
+        specifier: 2.1.92
+        version: 2.1.92
       '@babel/parser':
         specifier: 7.29.0
         version: 7.29.0
@@ -113,8 +113,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@anthropic-ai/claude-code@2.1.89':
-    resolution: {integrity: sha512-etjihHqVxj1RjS5Zu/o+rv3ojn1N7AWzfgIOCSSSncfyb4qJn9J677scj0LHIxtwzjgU7j1qAedXlXKxgkFG2w==}
+  '@anthropic-ai/claude-code@2.1.92':
+    resolution: {integrity: sha512-mNGw/IK3+1yHsQBeKaNtdTPCrQDkUEuNTJtm3OBTXs4bBkUVdIgRme/34ZnbZkl2VMMYPoNaTvqX2qJZ9EdSxQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2355,7 +2355,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
 
-  '@anthropic-ai/claude-code@2.1.89':
+  '@anthropic-ai/claude-code@2.1.92':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 # Wait 7 days (10080 minutes) before installing newly published packages.
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  - '@anthropic-ai/*'
   - '@socketaddon/*'
   - '@socketbin/*'
   - '@socketregistry/*'


### PR DESCRIPTION
Fixes deny-rule bypass (parse-fail fallback degradation) from v2.1.90. Also adds @anthropic-ai/* to minimumReleaseAgeExclude.