### PR TITLE
chore(deps): bump @socketsecurity/lib to 5.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/parser": "7.29.0",
     "@dotenvx/dotenvx": "1.52.0",
     "@oxlint/migrate": "1.51.0",
-    "@socketsecurity/lib": "5.13.0",
+    "@socketsecurity/lib": "5.14.0",
     "@socketsecurity/registry": "2.0.2",
     "@types/node": "24.9.2",
     "@types/picomatch": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
       '@socketsecurity/lib':
-        specifier: 5.13.0
-        version: 5.13.0(typescript@5.9.2)
+        specifier: 5.14.0
+        version: 5.14.0(typescript@5.9.2)
       '@socketsecurity/registry':
         specifier: 2.0.2
         version: 2.0.2(typescript@5.9.2)
@@ -1070,8 +1070,8 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/lib@5.13.0':
-    resolution: {integrity: sha512-BtpsibIaqDEXaXwihTGqQW0uPRixpedyEfmG3i6Vx2h8IpZ4Xw+T1Hc3cNqBND/67XFUuiygpPYJhhjjao0UWA==}
+  '@socketsecurity/lib@5.14.0':
+    resolution: {integrity: sha512-Cer/fXl07n1YU5eYzdkaTAPrO3XlYKDAhvFiMRglcm4fy8ycpzXEYI9Tz6rJ+jUGZx2I1I4w7LIQzWHT+bvMbQ==}
     engines: {node: '>=22', pnpm: '>=10.25.0'}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -3012,7 +3012,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@socketsecurity/lib@5.13.0(typescript@5.9.2)':
+  '@socketsecurity/lib@5.14.0(typescript@5.9.2)':
     optionalDependencies:
       typescript: 5.9.2
 


### PR DESCRIPTION
## Summary
- Bump `@socketsecurity/lib` from 5.13.0 to 5.14.0

## Test plan
- [ ] CI passes with updated dependency