### PR TITLE
chore(deps): narrow minimumReleaseAgeExclude to specific version

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 # Wait 7 days (10080 minutes) before installing newly published packages.
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - '@anthropic-ai/*'
+  - '@anthropic-ai/claude-code@2.1.92'
   - '@socketaddon/*'
   - '@socketbin/*'
   - '@socketregistry/*'


### PR DESCRIPTION
## Summary
- Narrows `@anthropic-ai/*` wildcard in `minimumReleaseAgeExclude` to `@anthropic-ai/claude-code@2.1.92`
- Tightest scope: only exempts the specific version we use, not all anthropic packages

## Test plan
- [ ] `pnpm install` succeeds