### PR TITLE
fix(ci): trigger required checks on automated PRs

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -267,6 +267,21 @@ jobs:
             --head "$BRANCH_NAME" \
             --base main
 
+      # Pushes made with GITHUB_TOKEN don't trigger other workflows.
+      # Close/reopen the PR to generate a pull_request.reopened event,
+      # which triggers required CI and enterprise audit workflows.
+      - name: Trigger CI checks
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
+        run: |
+          pr_number=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
+          if [ -n "$pr_number" ]; then
+            gh pr close "$pr_number"
+            gh pr reopen "$pr_number"
+          fi
+
       - name: Add job summary
         if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:


### PR DESCRIPTION
## Summary

- Pushes made with `GITHUB_TOKEN` don't trigger other workflows, so required CI and enterprise audit checks get stuck at "Waiting for workflow to run" on automated PRs created by the weekly update workflow.
- Added a close/reopen step after PR creation to generate a `pull_request.reopened` event, which triggers the required workflows.

## Test plan

- [ ] Run the weekly update workflow via `workflow_dispatch` and verify the PR is created, closed, and reopened
- [ ] Confirm CI and enterprise audit checks are triggered on the reopened PR