### PR TITLE
chore(ci): bump socket-registry action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
     with:
       fail-fast: false
       lint-script: 'pnpm run lint --all'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
 
       - name: Check for npm updates
         id: check
@@ -48,7 +48,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
 
       - name: Create update branch
         id: branch
@@ -60,7 +60,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -290,7 +290,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ec0af5ed4601f2bca8c042b290135c30854648d9 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@4edf2e3c3beff7d536e79ce43dfb61abba7cb537 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

Bump socket-registry action SHAs to the latest main after the full Layer 1-4 cascade (#209, #210, #211, #212).

### What changed upstream

- **Native pnpm**: `pnpm/action-setup` replaced with direct binary download (v10.33.0, checksum-verified)
- **Native zizmor**: Docker-based `zizmor-action` replaced with native binary (v1.23.1, checksum-verified)
- **sfw-free checksums**: SHA-256 verification on all sfw-free binary downloads
- **sfw shims**: All supported ecosystems (npm, yarn, pnpm, pip, uv, cargo) shimmed through the Socket firewall
- **No cache**: Removed pnpm cache from setup-node to eliminate cache-poisoning vectors
- **GIT_SSL_NO_VERIFY workaround**: Temporary fix until sfw-free sets GIT_SSL_CAINFO