### PR TITLE
chore: align engines to node >=18.20.8 and pnpm >=10.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=18.20.4",
-    "pnpm": ">=10.25.0"
+    "node": ">=18.20.8",
+    "pnpm": ">=10.33.0"
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Align engines.node and engines.pnpm to match packageManager and other Socket repos.