### PR TITLE
chore: add conventional commits guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ All shared standards (git, testing, code style, cross-platform, CI) defined in s
 
 **Quick references**:
 
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) `<type>(<scope>): <description>` - NO AI attribution
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) `<type>(<scope>): <description>` — Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf` — NO AI attribution
 - Scripts: Prefer `pnpm run foo --flag` over `foo:bar` scripts
 - Docs: Use `docs/` folder, lowercase-with-hyphens.md filenames, pithy writing with visuals
 - Dependencies: After `package.json` edits, run `pnpm install` to update `pnpm-lock.yaml`


### PR DESCRIPTION
## Summary

- Expand the Conventional Commits quick reference in CLAUDE.md to include the explicit list of valid types (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub