### PR TITLE
fix(config): add resolutionMode highest to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 ignoreDependencyScripts: true
 linkWorkspacePackages: false
+resolutionMode: highest
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Summary
- Add `resolutionMode: highest` to fix `ERR_PNPM_MISSING_TIME` behind Socket Firewall

## Test plan
- [ ] Verify `pnpm install` works locally
- [ ] Verify CI passes on all platforms (especially Windows)