### PR TITLE
chore(ci): bump socket-registry action refs to main (3362af95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main
 
       - name: Create update branch
         id: branch
@@ -62,7 +62,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@3362af95fadd1e325cb48e9ad6daff21c112bd72 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary
- Cascades the pnpm 11.0.0-rc.0 → 11.0.0-rc.2 bump from socket-registry
- Updates all `SocketDev/socket-registry/.github/...` pins to the new propagation SHA `3362af95fadd1e325cb48e9ad6daff21c112bd72`

## Test plan
- [ ] CI passes on this branch (reusable workflow pulls new setup action)
- [ ] pnpm 11.0.0-rc.2 is installed during setup