### PR TITLE
chore(ci): bump socket-registry actions to 13684cd8 (gh telemetry opt-out)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,7 +59,7 @@ jobs:
       contents: read
     steps:
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@d7b5d15a9be8973a5715459d12b9a033603a5ff5 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/valtown.yml
+++ b/.github/workflows/valtown.yml
@@ -74,7 +74,7 @@ jobs:
           echo "VALTOWN_TOKEN present (length: ${#VALTOWN_TOKEN})"
 
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@d7b5d15a9be8973a5715459d12b9a033603a5ff5 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
 
       - name: Create update branch
         id: branch
@@ -62,7 +62,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

- Bumps all `SocketDev/socket-registry/.github/*` pins to `13684cd8` (current propagation SHA). Previously `ebf1b48f` in most files, with `pages.yml` / `valtown.yml` at `d7b5d15a` — now unified.
- New SHA opts out of GitHub's on-by-default `gh` CLI telemetry via `DO_NOT_TRACK=1` and `GH_TELEMETRY=0`.

## Test plan

- [ ] CI runs green on the bumped pins.