### PR TITLE
style: rename catch (err|error) identifiers to catch (e)

### DIFF
--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -138,10 +138,10 @@ async function buildSource(
     const buildTime = Date.now() - startTime
 
     return { exitCode: 0, buildTime, result }
-  } catch (error) {
+  } catch (e) {
     if (!quiet) {
       logger.error('Source build failed')
-      console.error(error)
+      console.error(e)
     }
     return { exitCode: 1, buildTime: 0, result: null }
   }
@@ -247,9 +247,9 @@ async function watchBuild(options: WatchBuildOptions = {}): Promise<number> {
 
     // Wait indefinitely
     await new Promise<never>(() => {})
-  } catch (error) {
+  } catch (e) {
     if (!quiet) {
-      logger.error('Watch mode failed:', error)
+      logger.error('Watch mode failed:', e)
     }
     return 1
   }
@@ -475,8 +475,8 @@ async function main(): Promise<void> {
     if (exitCode !== 0) {
       process.exitCode = exitCode
     }
-  } catch (error) {
-    logger.error(`Build runner failed: ${getErrorMessage(error)}`)
+  } catch (e) {
+    logger.error(`Build runner failed: ${getErrorMessage(e)}`)
     process.exitCode = 1
   }
 }

--- a/scripts/check.mts
+++ b/scripts/check.mts
@@ -404,8 +404,8 @@ async function main(): Promise<void> {
       logger.success('All checks passed')
       printFooter()
     }
-  } catch (error) {
-    logger.error(`Check runner failed: ${errorMessage(error)}`)
+  } catch (e) {
+    logger.error(`Check runner failed: ${errorMessage(e)}`)
     process.exitCode = 1
   }
 }

--- a/scripts/fix.mts
+++ b/scripts/fix.mts
@@ -48,12 +48,12 @@ async function run(
       logger.warn(`${label || cmd}: exited ${result.code} (non-blocking)`)
     }
     return 0
-  } catch (error) {
+  } catch (e) {
     if (!required) {
-      logger.warn(`${label || cmd}: ${getErrorMessage(error)} (non-blocking)`)
+      logger.warn(`${label || cmd}: ${getErrorMessage(e)} (non-blocking)`)
       return 0
     }
-    throw error
+    throw e
   }
 }
 

--- a/scripts/lint.mts
+++ b/scripts/lint.mts
@@ -463,8 +463,8 @@ async function main(): Promise<void> {
         logger.success('All lint checks passed!')
       }
     }
-  } catch (error) {
-    logger.error(`Lint runner failed: ${errorMessage(error)}`)
+  } catch (e) {
+    logger.error(`Lint runner failed: ${errorMessage(e)}`)
     process.exitCode = 1
   }
 }

--- a/scripts/test.mts
+++ b/scripts/test.mts
@@ -559,12 +559,12 @@ async function main(): Promise<void> {
     } else {
       logger.success('All tests passed!')
     }
-  } catch (error) {
+  } catch (e) {
     // Ensure spinner is stopped
     try {
       spinner.stop()
     } catch {}
-    logger.error(`Test runner failed: ${errorMessage(error)}`)
+    logger.error(`Test runner failed: ${errorMessage(e)}`)
     process.exitCode = 1
   } finally {
     // Ensure spinner is stopped

--- a/scripts/tour.mts
+++ b/scripts/tour.mts
@@ -1594,8 +1594,8 @@ async function watch(
     try {
       await generate(refresh, minify, basePath, rest)
       console.log(`[watch] rebuilt at ${new Date().toLocaleTimeString()}`)
-    } catch (err) {
-      console.error(`[watch] rebuild failed:`, errorMessage(err))
+    } catch (e) {
+      console.error(`[watch] rebuild failed:`, errorMessage(e))
     } finally {
       building = false
       if (dirtyWhileBuilding) {
@@ -1818,10 +1818,10 @@ async function printDeployReceipt(
   if (summaryPath) {
     try {
       await fs.appendFile(summaryPath, summary + '\n')
-    } catch (err) {
+    } catch (e) {
       console.warn(
         '[valtown] could not write GITHUB_STEP_SUMMARY:',
-        (err as Error).message,
+        (e as Error).message,
       )
     }
   }

--- a/scripts/update.mts
+++ b/scripts/update.mts
@@ -97,12 +97,12 @@ async function main(): Promise<void> {
         logger.log('')
       }
     }
-  } catch (error) {
+  } catch (e) {
     if (!quiet) {
-      logger.fail(`Update failed: ${getErrorMessage(error)}`)
+      logger.fail(`Update failed: ${getErrorMessage(e)}`)
     }
     if (verbose) {
-      logger.error(error)
+      logger.error(e)
     }
     process.exitCode = 1
   }

--- a/scripts/validate/bundle-deps.mts
+++ b/scripts/validate/bundle-deps.mts
@@ -407,8 +407,8 @@ async function main(): Promise<void> {
 
     // Only fail on violations, not warnings
     process.exitCode = violations.length > 0 ? 1 : 0
-  } catch (error) {
-    const message = errorMessage(error)
+  } catch (e) {
+    const message = errorMessage(e)
     console.error('Validation failed:', message)
     process.exitCode = 1
   }

--- a/scripts/validate/esbuild-minify.mts
+++ b/scripts/validate/esbuild-minify.mts
@@ -64,8 +64,8 @@ async function validateEsbuildMinify(): Promise<EsbuildMinifyViolation[]> {
     }
 
     return violations
-  } catch (error) {
-    const message = errorMessage(error)
+  } catch (e) {
+    const message = errorMessage(e)
     console.error(`Failed to load esbuild config: ${message}`)
     process.exitCode = 1
     return []

--- a/scripts/validate/file-count.mts
+++ b/scripts/validate/file-count.mts
@@ -109,8 +109,8 @@ async function main(): Promise<void> {
     logger.log('')
 
     process.exitCode = 1
-  } catch (error) {
-    const message = errorMessage(error)
+  } catch (e) {
+    const message = errorMessage(e)
     logger.fail(`Validation failed: ${message}`)
     process.exitCode = 1
   }

--- a/scripts/validate/file-size.mts
+++ b/scripts/validate/file-size.mts
@@ -152,8 +152,8 @@ async function main(): Promise<void> {
     logger.log('')
 
     process.exitCode = 1
-  } catch (error) {
-    const message = errorMessage(error)
+  } catch (e) {
+    const message = errorMessage(e)
     logger.fail(`Validation failed: ${message}`)
     process.exitCode = 1
   }

--- a/scripts/validate/no-cdn-refs.mts
+++ b/scripts/validate/no-cdn-refs.mts
@@ -208,8 +208,8 @@ async function checkFileForCdnRefs(filePath: string): Promise<CdnViolation[]> {
     }
 
     return violations
-  } catch (error) {
-    const nodeError = error as NodeError
+  } catch (e) {
+    const nodeError = e as NodeError
     // Skip files we can't read (likely binary despite extension)
     if (nodeError.code === 'EISDIR' || nodeError.message.includes('ENOENT')) {
       return []
@@ -270,8 +270,8 @@ async function main(): Promise<void> {
     logger.log('')
 
     process.exitCode = 1
-  } catch (error) {
-    const message = errorMessage(error)
+  } catch (e) {
+    const message = errorMessage(e)
     logger.fail(`Validation failed: ${message}`)
     process.exitCode = 1
   }

--- a/val/audit.ts
+++ b/val/audit.ts
@@ -37,7 +37,7 @@ export const audit = async (
         meta: opts.meta ? JSON.stringify(opts.meta) : null,
       },
     })
-  } catch (err) {
-    console.warn('[val] audit write failed', err)
+  } catch (e) {
+    console.warn('[val] audit write failed', e)
   }
 }

--- a/val/auth-request.ts
+++ b/val/auth-request.ts
@@ -81,11 +81,11 @@ export const registerAuthRequest = (app: Hono<AppEnv>): void => {
           html: renderLoginEmail(code),
           text: renderLoginEmailText(code),
         })
-      } catch (err) {
+      } catch (e) {
         // Log-and-swallow. If the email provider hiccups we don't
         // reveal it to the client — the audit log preserves that we
         // tried, and the user realizes when their code doesn't arrive.
-        console.error('[val] email send failed', err)
+        console.error('[val] email send failed', e)
       }
       await audit(c, 'login_code_sent', { actor: rawEmail, success: true })
     } else {

--- a/val/db.ts
+++ b/val/db.ts
@@ -94,9 +94,9 @@ export const ensureDb = (async () => {
     await sqlite.execute(
       `CREATE INDEX IF NOT EXISTS idx_audit_action_ts ON audit_log(action, ts)`,
     )
-  } catch (err) {
-    console.error('[val] ensureDb failed', err)
-    throw err
+  } catch (e) {
+    console.error('[val] ensureDb failed', e)
+    throw e
   }
 })()
 
@@ -120,8 +120,8 @@ export const cleanOldRows = async (): Promise<void> => {
       sql: 'DELETE FROM audit_log WHERE ts < :c',
       args: { c: auditCutoff },
     })
-  } catch (err) {
-    console.warn('[val] cleanup failed', err)
+  } catch (e) {
+    console.warn('[val] cleanup failed', e)
   }
 }
 


### PR DESCRIPTION
Mechanical rename across 8 files — 20 catch clauses converted. tsgo --noEmit clean.