### PR TITLE
chore(ci): bump socket-registry refs to 0371e83f

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
       contents: read
     steps:
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
       contents: read
     steps:
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/valtown.yml
+++ b/.github/workflows/valtown.yml
@@ -74,7 +74,7 @@ jobs:
           echo "VALTOWN_TOKEN present (length: ${#VALTOWN_TOKEN})"
 
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/valtown.yml
+++ b/.github/workflows/valtown.yml
@@ -74,7 +74,7 @@ jobs:
           echo "VALTOWN_TOKEN present (length: ${#VALTOWN_TOKEN})"
 
       - name: Setup and install (checkout + Node + pnpm + install)
-        uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+        uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         with:
           checkout-fetch-depth: '1'
 

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
 
       - name: Create update branch
         id: branch
@@ -62,7 +62,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         if: always()
 
   notify:

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Create update branch
         id: branch
@@ -62,7 +62,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         if: always()
 
   notify:


### PR DESCRIPTION
Bumps `SocketDev/socket-registry` workflow/action pins to `0371e83f`.

This is the Layer 3 propagation SHA from socket-registry's recent cascade adding a runtime guard to the install action: it now fails fast with an actionable message when the consumer's `@socketsecurity/lib` is below the latest version published to npm. Below-floor versions ship a stubbed pacote fetcher that throws inside `downloadPackage` when the install action provisions ecc-agentshield.

socket-packageurl-js already pins `@socketsecurity/lib` at `5.24.0` (the current npm latest), so this is a mechanical bump — no consumer code changes. Also catches this repo up from the older `13684cd8` pin (skipping the intermediate `444b6415` cascade).

## Test plan
- [ ] CI pipeline (check + matrix tests) passes
- [ ] Audit GitHub Actions check passes